### PR TITLE
Reflect Node version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo allows you to populate your database with quiz questions for [Flutter 
 
 ## Instructions
 
-Requires Node.js >= 8. 
+Requires Node.js >=8 <13
 
 1. Clone this repo, cd into it, and run `npm install`. 
 2. Download your service account (generate private key) from the [Firebase Console](https://console.firebase.google.com) under settings, then save it in the root of this project as `credentials.json`.


### PR DESCRIPTION
Node 13.x and 14.x appear incompatible at present with the google-cloud/firestore transitive dependency, due to an issue with GRPC. I believe there is a work-around, by changing compiler flags and rebuilding etc. For a script such as this, probably easier to use nvm etc to use 12.x for this.